### PR TITLE
Allow running demo within the project

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -9,13 +9,13 @@
     <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
 
     <!-- Imports custom element -->
-    <link rel="import" href="rubygoal-player.html">
+    <link rel="import" href="bower_components/rubygoal-webplayer/rubygoal-player.html">
 
 </head>
 <body>
 
     <!-- Runs custom element -->
-    <rubygoal-player src="examples/recorded_game.json"></rubygoal-player>
+    <rubygoal-player src="recorded_game.json"></rubygoal-player>
 
 </body>
 </html>


### PR DESCRIPTION
`index.html` was included in the `example` directory, allowing to run the demo within the project and making it unnecessary to create a different project for testing purposes.
